### PR TITLE
[TH2-4851] Clean batch and buffer if error happened during processing

### DIFF
--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
@@ -243,10 +243,13 @@ private class ParsedStoredMessageHandler(
         if (details.isEmpty()) {
             return
         }
-        handler.checkAndWaitForRequestLimit(details.size)
-        decoder.sendBatchMessage(batch, details, details.first().storedMessage.streamName)
-        details.clear()
-        batch.clear()
+        try {
+            handler.checkAndWaitForRequestLimit(details.size)
+            decoder.sendBatchMessage(batch, details, details.first().storedMessage.streamName)
+        } finally {
+            details.clear()
+            batch.clear()
+        }
     }
 }
 


### PR DESCRIPTION
This is done to avoid double processing of the current batch if there are some problems with attributes