### PR TITLE
[TH2-4911] Fix problem with grouping different groups in a single batch

### DIFF
--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/AbstractDataSink.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/AbstractDataSink.kt
@@ -16,6 +16,7 @@
 
 package com.exactpro.th2.lwdataprovider.handlers
 
+import com.exactpro.th2.lwdataprovider.BasicResponseHandler
 import com.exactpro.th2.lwdataprovider.ResponseHandler
 import com.exactpro.th2.lwdataprovider.db.EventDataSink
 import com.exactpro.th2.lwdataprovider.db.MessageDataSink
@@ -41,7 +42,7 @@ class SingleTypeDataSink<T>(
     limit: Int? = null,
 ) : GenericDataSink<T, T>(handler, limit, { it })
 
-abstract class AbstractMessageDataSink<M, T>(
-    override val handler: ResponseHandler<T>,
+abstract class AbstractMessageDataSink<M, T, H : BasicResponseHandler>(
+    override val handler: H,
     limit: Int? = null,
 ) : AbstractBasicDataSink(handler, limit), MessageDataSink<M, T>

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
@@ -111,13 +111,14 @@ fun createBatches(
     startTimestamp: Instant,
     end: Instant,
     aliasIndexOffset: Int = 0,
+    group: String = "test",
 ): List<StoredGroupedMessageBatch> =
     ArrayList<StoredGroupedMessageBatch>().apply {
         val startSeconds = startTimestamp.epochSecond
         repeat(batchesCount) {
             val start = Instant.ofEpochSecond(startSeconds + it * increase * (messagesPerBatch - overlapCount), startTimestamp.nano.toLong())
             add(StoredGroupedMessageBatch(
-                "test",
+                group,
                 createStoredMessages(
                     "test${it + aliasIndexOffset}",
                     Instant.now().run { epochSecond * 1_000_000_000 + nano },


### PR DESCRIPTION
Each group must be processed separately from the others. The problem when messages from several groups go into the same batch is fixed