### PR TITLE
[TH2-5046] Correct error reporting for group download

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ spec:
 + Add support for requesting message groups in reversed order
 + Add filter by stream to gRPC API for group search request
 
+### Fixed:
+
++ error reporting when executing group search (if error occurs during a call to the Cradle API stream were closed before the error was reported)
+
 ## 2.1.0
 
 + Updated bom: `4.5.0-dev`

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
@@ -264,9 +264,8 @@ class SearchMessagesHandler(
                 markerAsGroup = true,
                 limit = request.limit,
             )
-            try {
-                rootSink.use { sink ->
-
+            rootSink.use { sink ->
+                try {
                     val parameters = CradleGroupRequest(
                         preFilter = createInitialPrefilter(request),
                     )
@@ -301,10 +300,10 @@ class SearchMessagesHandler(
                             }
                         } while (keepPulling)
                     }
+                } catch (ex: Exception) {
+                    logger.error("Error getting messages group", ex)
+                    rootSink.onError(ex)
                 }
-            } catch (ex: Exception) {
-                logger.error("Error getting messages group", ex)
-                rootSink.onError(ex)
             }
         }
     }


### PR DESCRIPTION
There was a bug that the **CLOSE** event was emitted before the **ERROR** event in case the call to Cradle API throws an exception. This change fixes that problem and also tries to set the error status to the response in that case