### PR TITLE
[TH2-5103] Add batch size limit in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lightweight data provider (2.3.1)
+# Lightweight data provider (2.4.1)
 
 # Overview
 This component serves as a data provider for [th2-data-services](https://github.com/th2-net/th2-data-services). It will connect to the cassandra database via [cradle api](https://github.com/th2-net/cradleapi) and expose the data stored in there as REST resources.
@@ -114,7 +114,7 @@ spec:
 #   keepAliveTimeout: 5000 # timeout in milliseconds. keep_alive sending frequency
 #   maxBufferDecodeQueue: 10000 # buffer size for messages that sent to decode but anwers hasn't been received 
 #   decodingTimeout: 60000 # timeout expecting answers from codec. 
-#   batchSize: 100 # batch size from codecs
+#   batchSizeBytes: 256KB # the max size of the batch in bytes. You can use 'MB,KB' suffixes or a plain int value
 #   codecUsePinAttributes: true # send raw message to specified codec (true) or send to all codecs (false) 
 #   responseFormats: string list # resolve data for selected formats only. (allowed values: BASE_64, PARSED)
 #   flushSseAfter: 0 # number of SSE emitted before flushing data to the output stream. 0 means flush after each event
@@ -175,9 +175,9 @@ spec:
     port: 8080 
     
 #   keepAliveTimeout: 5000 # timeout in milliseconds. keep_alive sending frequency
-#   maxBufferDecodeQueue: 10000 # buffer size for messages that sent to decode but anwers hasn't been received 
+#   maxBufferDecodeQueue: 10000 # buffer size for messages that sent to decode but answers hasn't been received 
 #   decodingTimeout: 60000 # timeout expecting answers from codec. 
-#   batchSize: 100 # batch size from codecs
+#   batchSizeBytes: 256KB # the max size of the batch in bytes. You can use 'MB,KB' suffixes or a plain int value
 #   codecUsePinAttributes: true # send raw message to specified codec (true) or send to all codecs (false) 
 #   responseFormats: string list # resolve data for selected formats only. (allowed values: BASE_64, PARSED)
     
@@ -223,6 +223,12 @@ spec:
 
 # Release notes:
 
+## 2.4.0
+
++ Add `batchSizeBytes` parameter to limit batch size by size in bytes rather than count of messages.
++ Parameter `batchSize` deprecated. It no longer has any effect on component configuration.
+  The maximum batch size in messages is computed based on `bufferPerQuery` or `maxBufferDecodeQueue` if previous parameter is not set.
+
 ## 2.3.1
 
 ### Fixed:
@@ -233,7 +239,7 @@ spec:
 
 ### Feature
 
-+ added gzipCompressionLevel option.
++ Add `gzipCompressionLevel` parameter into configuration
 
 ## 2.2.1
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ spec:
 ## 2.4.0
 
 + Add `batchSizeBytes` parameter to limit batch size by size in bytes rather than count of messages.
-+ Parameter `batchSize` deprecated. It no longer has any effect on component configuration.
++ Parameters `batchSize` and `groupRequestBuffer` removed.
   The maximum batch size in messages is computed based on `bufferPerQuery` or `maxBufferDecodeQueue` if previous parameter is not set.
 
 ## 2.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 kotlin.code.style=official
 
-release_version=2.3.0
+release_version=2.4.0
 description='th2 Lightweight data provider component'
 vcs_url=https://github.com/th2-net/th2-lw-data-provider
 docker_image_name=

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/ByteSizeDeserializer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/ByteSizeDeserializer.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.configuration
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+internal class ByteSizeDeserializer : StdDeserializer<Int?>(Int::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Int? {
+        return when (p.currentToken) {
+            JsonToken.VALUE_NUMBER_INT, JsonToken.VALUE_NUMBER_FLOAT -> p.intValue
+            JsonToken.VALUE_STRING ->
+                convertStringToByteSize(p.valueAsString)
+
+            JsonToken.VALUE_NULL -> null
+            else -> error("cannot convert ${p.currentToken.name} to an int")
+        }
+    }
+
+    private fun convertStringToByteSize(byteSize: String): Int {
+        return try {
+            when {
+                byteSize.endsWith(MEGA_BYTES, ignoreCase = true) ->
+                    byteSize.substring(0, byteSize.length - MEGA_BYTES.length)
+                        .toInt() * 1024 * 1024
+
+                byteSize.endsWith(KILO_BYTES, ignoreCase = true) ->
+                    byteSize.substring(0, byteSize.length - KILO_BYTES.length)
+                        .toInt() * 1024
+
+                else -> byteSize.toInt()
+            }
+        } catch (ex: Exception) {
+            throw IllegalArgumentException("cannot parse bytes size value from '$byteSize'", ex)
+        }
+    }
+
+    companion object {
+        private const val MEGA_BYTES = "mb"
+        private const val KILO_BYTES = "kb"
+        private const val serialVersionUID: Long = 9039695677466910433L
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
@@ -17,6 +17,7 @@
 package com.exactpro.th2.lwdataprovider.configuration
 
 import com.exactpro.th2.lwdataprovider.entities.internal.ResponseFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import mu.KotlinLogging
 import java.util.*
 import kotlin.math.max
@@ -48,6 +49,7 @@ class CustomConfigurationClass(
     val useTransportMode: Boolean? = null,
     val flushSseAfter: Int? = null,
     val gzipCompressionLevel: Int? = null,
+    @JsonDeserialize(using = ByteSizeDeserializer::class)
     val batchSizeBytes: Int? = null,
 )
 

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
@@ -78,7 +78,7 @@ class Configuration(customConfiguration: CustomConfigurationClass) {
     val useTransportMode: Boolean = VariableBuilder.getVariable(customConfiguration::useTransportMode, false)
     val flushSseAfter: Int = VariableBuilder.getVariable(customConfiguration::flushSseAfter, 0)
     val gzipCompressionLevel: Int = VariableBuilder.getVariable(customConfiguration::gzipCompressionLevel, -1)
-    val batchSizeBytes: Int = VariableBuilder.getVariable(customConfiguration::batchSizeBytes, 256 * 1024 * 1024)
+    val batchSizeBytes: Int = VariableBuilder.getVariable(customConfiguration::batchSizeBytes, 256 * 1024)
     init {
         require(bufferPerQuery <= maxBufferDecodeQueue) {
             "buffer per queue ($bufferPerQuery) must be less or equal to the total buffer size ($maxBufferDecodeQueue)"

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
@@ -33,15 +33,9 @@ class CustomConfigurationClass(
     val responseQueueSize: Int? = null,
     val execThreadPoolSize: Int? = null,
     val convThreadPoolSize: Int? = null,
-    @Deprecated("use parameter batchSizeBytes instead to set limit in bytes. " +
-            "This parameter does not have any effect anymore. " +
-            "The batch size limit in messages is defined by bufferPerQuery or maxBufferDecodeQueue (if bufferPerQuery is not set)")
-    val batchSize: Int? = null,
     val mode: String? = null,
     val grpcBackPressure : Boolean? = null,
     val bufferPerQuery: Int? = null,
-    @Deprecated("Parameter is not longer used because the batches for group should not overlap")
-    val groupRequestBuffer: Int? = null,
     val responseFormats: Set<String>? = null,
     val grpcBackPressureReadinessTimeoutMls: Long? = null,
     val codecUsePinAttributes: Boolean? = null,

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/handlers/SearchMessagesHandler.kt
@@ -95,15 +95,15 @@ class SearchMessagesHandler(
                         TransportParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     } else {
                         ProtoParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     }
                 },
@@ -165,15 +165,15 @@ class SearchMessagesHandler(
                         TransportParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     } else {
                         ProtoParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     }
                 }
@@ -204,15 +204,15 @@ class SearchMessagesHandler(
                         TransportParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     } else {
                         ProtoParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
-                            configuration.batchSize
+                            configuration.batchSize,
+                            configuration.batchSizeBytes,
                         )
                     }
                 }
@@ -248,16 +248,16 @@ class SearchMessagesHandler(
                         TransportParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
                             configuration.batchSize,
+                            configuration.batchSizeBytes,
                             markerAsGroup = true
                         )
                     } else {
                         ProtoParsedStoredMessageHandler(
                             requestContext,
                             decoder,
-                            dataMeasurement,
                             configuration.batchSize,
+                            configuration.batchSizeBytes,
                             markerAsGroup = true
                         )
                     }

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/configuration/TestCustomConfigurationClassDeserialization.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/configuration/TestCustomConfigurationClassDeserialization.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.configuration
+
+import com.exactpro.th2.common.schema.factory.CommonFactory
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+
+class TestCustomConfigurationClassDeserialization {
+    @ParameterizedTest
+    @CsvSource(
+        "10,10",
+        "5KB,5120",
+        "5Kb,5120",
+        "5kb,5120",
+        "5MB,5242880",
+        "5Mb,5242880",
+        "5mb,5242880",
+    )
+    fun `bytes size deserialization`(configValue: String, expectedSize: Int) {
+        val cfg = CommonFactory.MAPPER.readValue<CustomConfigurationClass>(
+            """
+            {
+                "batchSizeBytes": "$configValue"
+            }
+            """.trimIndent()
+        )
+        expectThat(cfg)
+            .get { batchSizeBytes }
+            .isNotNull()
+            .isEqualTo(expectedSize)
+    }
+
+    @Test
+    fun `null deserialization`() {
+        val cfg = CommonFactory.MAPPER.readValue<CustomConfigurationClass>(
+            """
+            {
+                "batchSizeBytes": null
+            }
+            """.trimIndent()
+        )
+        expectThat(cfg)
+            .get { batchSizeBytes }
+            .isNull()
+    }
+}

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/db/integration/TestCradleMessageExtractorIntegration.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/db/integration/TestCradleMessageExtractorIntegration.kt
@@ -100,7 +100,10 @@ class TestCradleMessageExtractorIntegration : AbstractCradleIntegrationTest() {
                 startTime = startTime.plusNanos(1)
             }
         }
-        cradleStorage.storeGroupedMessageBatch(batchToStore)
+
+        retryUntilPageFound(tries = 3) {
+            cradleStorage.storeGroupedMessageBatch(batchToStore)
+        }
     }
 
     @TestFactory

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/db/integration/TestCradleMessageExtractorIntegration.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/db/integration/TestCradleMessageExtractorIntegration.kt
@@ -76,7 +76,11 @@ class TestCradleMessageExtractorIntegration : AbstractCradleIntegrationTest() {
                 )
                 startTime = startTime.plusNanos(5)
             }
-        }.also(cradleStorage::storeGroupedMessageBatch)
+        }.also {
+            retryUntilPageFound(tries = 3) {
+                cradleStorage.storeGroupedMessageBatch(it)
+            }
+        }
         // We need to have multiple pages for proper testing
         // But because of the verifications in cradle we cannot create pages in the past
         // So we increase timestamp into the future to create a new page

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/handlers/TestSearchMessagesHandler.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/handlers/TestSearchMessagesHandler.kt
@@ -561,8 +561,9 @@ internal class TestSearchMessagesHandler {
         executor,
         Configuration(
             CustomConfigurationClass(
-                batchSize = 3,
+                bufferPerQuery = 4,
                 useTransportMode = useTransportMode,
+                batchSizeBytes = 300,
             )
         )
     )


### PR DESCRIPTION
The batch size limit by the number of messages in it is not efficient and might cause problems in the case of big messages. In order to mediate the problem we replace this limit with a limit by batch's bytes