### PR TITLE
[TH2-5139] Add API for submitting download task and checking its status

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ spec:
   + GET `/download/{taskID}` - execute task
   + GET `/download/{taskID}/status` - get task status
   + DELETE `/download/{taskID}` - remove task
++ Add parameter `downloadTaskTTL` to clean up the completed or not started task after the specified time in milliseconds. 1 hour by default.
 + Add `EXTERNAL_CONTEXT_PATH` env variable to inform provider about external context that is used in requests
 
 ## 2.5.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lightweight data provider (2.5.2)
+# Lightweight data provider (2.6.0)
 
 # Overview
 This component serves as a data provider for [th2-data-services](https://github.com/th2-net/th2-data-services). It will connect to the cassandra database via [cradle api](https://github.com/th2-net/cradleapi) and expose the data stored in there as REST resources.
@@ -223,6 +223,15 @@ spec:
 ```
 
 # Release notes:
+
+## 2.6.0
+
++ Add download task endpoints:
+  + POST `/download` - register task
+  + GET `/download/{taskID}` - execute task
+  + GET `/download/{taskID}/status` - get task status
+  + DELETE `/download/{taskID}` - remove task
++ Add `EXTERNAL_CONTEXT_PATH` env variable to inform provider about external context that is used in requests
 
 ## 2.5.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 
 kotlin.code.style=official
 
-release_version=2.5.2
+release_version=2.6.0
 description='th2 Lightweight data provider component'
 vcs_url=https://github.com/th2-net/th2-lw-data-provider
 docker_image_name=

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/Main.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/Main.kt
@@ -87,11 +87,9 @@ class Main {
     private fun startServer() {
         setupMetrics(context)
         
-        context.keepAliveHandler.start()
-        context.timeoutHandler.start()
+        context.start()
 
-        resources += AutoCloseable {  context.keepAliveHandler.stop() }
-        resources += AutoCloseable {  context.timeoutHandler.stop() }
+        resources += AutoCloseable {  context.stop() }
 
         @Suppress("LiftReturnOrAssignment")
         when (context.configuration.mode) {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/configuration/Configuration.kt
@@ -20,6 +20,7 @@ import com.exactpro.th2.lwdataprovider.entities.internal.ResponseFormat
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import mu.KotlinLogging
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 
@@ -47,6 +48,7 @@ class CustomConfigurationClass(
     val gzipCompressionLevel: Int? = null,
     @JsonDeserialize(using = ByteSizeDeserializer::class)
     val batchSizeBytes: Int? = null,
+    val downloadTaskTTL: Long? = null,
 )
 
 class Configuration(customConfiguration: CustomConfigurationClass) {
@@ -76,6 +78,7 @@ class Configuration(customConfiguration: CustomConfigurationClass) {
     val flushSseAfter: Int = VariableBuilder.getVariable(customConfiguration::flushSseAfter, 0)
     val gzipCompressionLevel: Int = VariableBuilder.getVariable(customConfiguration::gzipCompressionLevel, -1)
     val batchSizeBytes: Int = VariableBuilder.getVariable(customConfiguration::batchSizeBytes, 256 * 1024)
+    val downloadTaskTTL: Long = VariableBuilder.getVariable(customConfiguration::downloadTaskTTL, TimeUnit.HOURS.toMillis(1))
     init {
         require(bufferPerQuery <= maxBufferDecodeQueue) {
             "buffer per queue ($bufferPerQuery) must be less or equal to the total buffer size ($maxBufferDecodeQueue)"
@@ -96,6 +99,7 @@ class Configuration(customConfiguration: CustomConfigurationClass) {
         require(gzipCompressionLevel <= 9 && gzipCompressionLevel >= -1) {
             "gzipCompressionLevel must be integer in the [-1, 9] range"
         }
+        require(downloadTaskTTL > 0) { "negative download task TTL: $downloadTaskTTL" }
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/entities/internal/ResponseFormat.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/entities/internal/ResponseFormat.kt
@@ -33,5 +33,11 @@ enum class ResponseFormat {
                 error("only one parsed format can be specified in $formats")
             }
         }
+
+        @JvmStatic
+        fun isValidCombination(formats: Set<ResponseFormat>): Boolean {
+            if (formats.size <= 1) return true
+            return !(PROTO_PARSED in formats && JSON_PARSED in formats)
+        }
     }
 }

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/entities/requests/MessagesGroupRequest.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/entities/requests/MessagesGroupRequest.kt
@@ -35,7 +35,8 @@ data class MessagesGroupRequest(
     val responseFormats: Set<ResponseFormat>? = null,
     val includeStreams: Set<ProviderMessageStream> = emptySet(),
     val limit: Int? = null,
-    val searchDirection: SearchDirection = SearchDirection.next
+    val searchDirection: SearchDirection = SearchDirection.next,
+    val failFast: Boolean = false, // for backward compatibility
 ) {
     init {
         if (!responseFormats.isNullOrEmpty()) {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -23,9 +23,11 @@ import com.exactpro.th2.lwdataprovider.SseResponseBuilder
 import com.exactpro.th2.lwdataprovider.entities.exceptions.InvalidRequestException
 import com.exactpro.th2.lwdataprovider.entities.internal.ProviderEventId
 import com.exactpro.th2.lwdataprovider.entities.requests.SearchDirection
+import com.exactpro.th2.lwdataprovider.http.serializers.BookIdDeserializer
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer53
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer53Transport
+import com.fasterxml.jackson.databind.module.SimpleModule
 import io.javalin.Javalin
 import io.javalin.config.JavalinConfig
 import io.javalin.http.BadRequestResponse
@@ -135,7 +137,13 @@ class HttpServer(private val context: Context) {
 
         app = Javalin.create {
             it.showJavalinBanner = false
-            it.jsonMapper(JavalinJackson(jacksonMapper))
+            it.jsonMapper(JavalinJackson(
+                jacksonMapper.registerModule(
+                    SimpleModule("th2").apply {
+                        addDeserializer(BookId::class.java, BookIdDeserializer())
+                    }
+                )
+            ))
 //            it.plugins.enableDevLogging()
             it.plugins.register(MicrometerPlugin.create { micrometer ->
                 micrometer.registry =

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -136,6 +136,9 @@ class HttpServer(private val context: Context) {
         )
 
         app = Javalin.create {
+            System.getenv(CONTEXT_PATH_ENV)?.takeUnless(String::isBlank)?.also { path ->
+                it.routing.contextPath = path
+            }
             it.showJavalinBanner = false
             it.jsonMapper(JavalinJackson(
                 jacksonMapper.registerModule(
@@ -216,6 +219,8 @@ class HttpServer(private val context: Context) {
 
     companion object {
         private val logger = KotlinLogging.logger {}
+
+        private const val CONTEXT_PATH_ENV = "CONTEXT_PATH"
 
         const val TIME_EXAMPLE =
             "Every value that is greater than 1_000_000_000 ^ 2 will be interpreted as nanos. Otherwise, as millis.\n" +

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -133,6 +133,14 @@ class HttpServer(private val context: Context) {
                 context.searchMessagesHandler,
                 context.requestsDataMeasurement,
             ),
+            TaskDownloadHandler(
+                configuration,
+                context.convExecutor,
+                sseResponseBuilder,
+                context.keepAliveHandler,
+                context.searchMessagesHandler,
+                context.requestsDataMeasurement,
+            ),
         )
 
         app = Javalin.create {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -158,7 +158,7 @@ class HttpServer(private val context: Context) {
                 it.plugins.enableDevLogging()
             } else {
                 it.requestLogger.http { ctx, time ->
-                    logger.info { "Request ${ctx.path()} executed with status ${ctx.status()}: ${time}.ms" }
+                    logger.info { "Request ${ctx.method().name} '${ctx.path()}' executed with status ${ctx.status()}: ${time}.ms" }
                 }
             }
             it.plugins.register(MicrometerPlugin.create { micrometer ->

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -154,7 +154,13 @@ class HttpServer(private val context: Context) {
                     }
                 )
             ))
-//            it.plugins.enableDevLogging()
+            if (logger.isTraceEnabled) {
+                it.plugins.enableDevLogging()
+            } else {
+                it.requestLogger.http { ctx, time ->
+                    logger.info { "Request ${ctx.path()} executed with status ${ctx.status()}: ${time}.ms" }
+                }
+            }
             it.plugins.register(MicrometerPlugin.create { micrometer ->
                 micrometer.registry =
                     PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM)

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -136,9 +136,6 @@ class HttpServer(private val context: Context) {
         )
 
         app = Javalin.create {
-            System.getenv(CONTEXT_PATH_ENV)?.takeUnless(String::isBlank)?.also { path ->
-                it.routing.contextPath = path
-            }
             it.showJavalinBanner = false
             it.jsonMapper(JavalinJackson(
                 jacksonMapper.registerModule(
@@ -181,6 +178,9 @@ class HttpServer(private val context: Context) {
 
     private fun setupReDoc(it: JavalinConfig) {
         val reDocConfiguration = ReDocConfiguration()
+        System.getenv(CONTEXT_PATH_ENV)?.takeUnless(String::isBlank)?.also { path ->
+            reDocConfiguration.basePath = path
+        }
         it.plugins.register(ReDocPlugin(reDocConfiguration))
     }
 

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -210,7 +210,7 @@ class HttpServer(private val context: Context) {
                         "Light Weight Data Provider provides you with fast access to data in Cradle"
                     openApiInfo.contact = openApiContact
                     openApiInfo.license = openApiLicense
-                    openApiInfo.version = "2.2.0"
+                    openApiInfo.version = "2.6.0"
                 }.withServer { openApiServer ->
                     openApiServer.url = "http://localhost:{port}"
                     openApiServer.addVariable("port", "8080", arrayOf("8080"), "Port of the server")

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/HttpServer.kt
@@ -27,6 +27,7 @@ import com.exactpro.th2.lwdataprovider.http.serializers.BookIdDeserializer
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer53
 import com.exactpro.th2.lwdataprovider.producers.MessageProducer53Transport
+import com.exactpro.th2.lwdataprovider.workers.TaskManager
 import com.fasterxml.jackson.databind.module.SimpleModule
 import io.javalin.Javalin
 import io.javalin.config.JavalinConfig
@@ -140,6 +141,7 @@ class HttpServer(private val context: Context) {
                 context.keepAliveHandler,
                 context.searchMessagesHandler,
                 context.requestsDataMeasurement,
+                context.taskManager,
             ),
         )
 

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/SseRequestContext.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/SseRequestContext.kt
@@ -75,7 +75,7 @@ class HttpMessagesRequestHandler(
                 if (jsonFormatter != null && requestedMessage.protoMessage == null && requestedMessage.transportMessage == null) {
                     builder.codecTimeoutError(requestedMessage.storedMessage.id, counter).also {
                         if (failFast) {
-                            LOGGER.info { "Codec timeout. Canceling processing due to fail-fast strategy" }
+                            LOGGER.warn { "Codec timeout. Canceling processing due to fail-fast strategy" }
                             // note that this might not stop the processing right away
                             // this is called on a different thread
                             // so some messages might be loaded before the processing is canceled

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/SseRequestContext.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/SseRequestContext.kt
@@ -32,6 +32,7 @@ import com.exactpro.th2.lwdataprovider.handlers.MessageResponseHandler
 import com.exactpro.th2.lwdataprovider.metrics.HttpWriteMetrics
 import com.exactpro.th2.lwdataprovider.producers.JsonFormatter
 import com.exactpro.th2.lwdataprovider.producers.ParsedFormats
+import mu.KotlinLogging
 import org.apache.commons.lang3.exception.ExceptionUtils
 import java.time.Duration
 import java.util.EnumSet
@@ -49,6 +50,7 @@ class HttpMessagesRequestHandler(
     dataMeasurement: DataMeasurement,
     maxMessagesPerRequest: Int = 0,
     responseFormats: Set<ResponseFormat> = EnumSet.of(ResponseFormat.BASE_64, ResponseFormat.PROTO_PARSED),
+    private val failFast: Boolean = false,
 ) : MessageResponseHandler(dataMeasurement, maxMessagesPerRequest), KeepAliveListener {
     private val includeRaw: Boolean = responseFormats.isEmpty() || ResponseFormat.BASE_64 in responseFormats
     private val jsonFormatter: JsonFormatter? = (responseFormats - ResponseFormat.BASE_64).run {
@@ -71,7 +73,15 @@ class HttpMessagesRequestHandler(
         val future: CompletableFuture<SseEvent> = data.completed.thenApplyAsync({ requestedMessage: RequestedMessage ->
             dataMeasurement.start("convert_to_json").use {
                 if (jsonFormatter != null && requestedMessage.protoMessage == null && requestedMessage.transportMessage == null) {
-                    builder.codecTimeoutError(requestedMessage.storedMessage.id, counter)
+                    builder.codecTimeoutError(requestedMessage.storedMessage.id, counter).also {
+                        if (failFast) {
+                            LOGGER.info { "Codec timeout. Canceling processing due to fail-fast strategy" }
+                            // note that this might not stop the processing right away
+                            // this is called on a different thread
+                            // so some messages might be loaded before the processing is canceled
+                            fail()
+                        }
+                    }
                 } else {
                     builder.build(
                         requestedMessage, jsonFormatter, includeRaw,
@@ -104,6 +114,15 @@ class HttpMessagesRequestHandler(
         if (buffer.isNotEmpty()) return false
         val counter = indexer.nextIndex()
         return buffer.offer({ builder.build(scannedObjectInfo, counter) }, duration.toMillis(), TimeUnit.MILLISECONDS)
+    }
+
+    private fun fail() {
+        cancel()
+        buffer.put { SseEvent.Closed }
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
     }
 }
 

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
@@ -327,6 +327,7 @@ class TaskDownloadHandler(
         COMPLETED,
         COMPLETED_WITH_ERRORS,
         CANCELED,
+        CANCELED_WITH_ERRORS,
     }
 
     private class TaskInformation(
@@ -373,7 +374,11 @@ class TaskDownloadHandler(
                 TaskStatus.EXECUTING_WITH_ERRORS ->
                     TaskStatus.COMPLETED_WITH_ERRORS
 
-                else ->
+                TaskStatus.CREATED,
+                TaskStatus.EXECUTING,
+                TaskStatus.COMPLETED,
+                TaskStatus.COMPLETED_WITH_ERRORS,
+                TaskStatus.CANCELED_WITH_ERRORS ->
                     TaskStatus.COMPLETED
             }
         }
@@ -382,12 +387,16 @@ class TaskDownloadHandler(
             LOGGER.trace { "Task $taskID canceled" }
             _status = when (_status) {
                 TaskStatus.EXECUTING_WITH_ERRORS ->
-                    TaskStatus.EXECUTING_WITH_ERRORS
+                    TaskStatus.CANCELED_WITH_ERRORS
 
-                TaskStatus.COMPLETED_WITH_ERRORS, TaskStatus.COMPLETED ->
+                TaskStatus.COMPLETED_WITH_ERRORS,
+                TaskStatus.COMPLETED ->
                     _status
 
-                else ->
+                TaskStatus.CREATED,
+                TaskStatus.EXECUTING,
+                TaskStatus.CANCELED,
+                TaskStatus.CANCELED_WITH_ERRORS ->
                     TaskStatus.CANCELED
             }
             handler?.also {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.http
+
+import com.exactpro.cradle.BookId
+import com.exactpro.cradle.Direction
+import com.exactpro.th2.common.event.EventUtils
+import com.exactpro.th2.lwdataprovider.CancelableResponseHandler
+import com.exactpro.th2.lwdataprovider.SseEvent
+import com.exactpro.th2.lwdataprovider.SseResponseBuilder
+import com.exactpro.th2.lwdataprovider.configuration.Configuration
+import com.exactpro.th2.lwdataprovider.db.DataMeasurement
+import com.exactpro.th2.lwdataprovider.entities.internal.ResponseFormat
+import com.exactpro.th2.lwdataprovider.entities.requests.MessagesGroupRequest
+import com.exactpro.th2.lwdataprovider.entities.requests.ProviderMessageStream
+import com.exactpro.th2.lwdataprovider.entities.requests.SearchDirection
+import com.exactpro.th2.lwdataprovider.handlers.SearchMessagesHandler
+import com.exactpro.th2.lwdataprovider.http.listener.ProgressListener
+import com.exactpro.th2.lwdataprovider.http.serializers.CustomMillisOrNanosInstantDeserializer
+import com.exactpro.th2.lwdataprovider.http.util.writeJsonStream
+import com.exactpro.th2.lwdataprovider.workers.KeepAliveHandler
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import io.javalin.Javalin
+import io.javalin.http.Context
+import io.javalin.http.HttpStatus
+import io.javalin.http.bodyValidator
+import mu.KotlinLogging
+import org.apache.commons.lang3.exception.ExceptionUtils
+import java.time.Instant
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.Executor
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.function.Supplier
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+class TaskDownloadHandler(
+    private val configuration: Configuration,
+    private val convExecutor: Executor,
+    private val sseResponseBuilder: SseResponseBuilder,
+    private val keepAliveHandler: KeepAliveHandler,
+    private val searchMessagesHandler: SearchMessagesHandler,
+    private val dataMeasurement: DataMeasurement,
+) : JavalinHandler {
+    private val tasksLock = ReentrantReadWriteLock()
+    private val tasks: MutableMap<TaskID, TaskInformation> = HashMap()
+
+    override fun setup(app: Javalin, context: JavalinContext) {
+        app.post(DOWNLOAD_ROUTE, this::registerTask)
+        app.get(TASK_STATUS_ROUTE, this::getTaskStatus)
+        app.get(TASK_ROUTE, this::executeTask)
+        app.delete(TASK_ROUTE, this::deleteTask)
+    }
+
+    private fun deleteTask(context: Context) {
+        val taskID = TaskID.create(context.pathParam(TASK_ID))
+        LOGGER.info { "Removing task $taskID" }
+        val removed = tasksLock.write { tasks.remove(taskID) }
+        if (removed == null) {
+            LOGGER.error { "Task $taskID not found" }
+            context.status(HttpStatus.NOT_FOUND)
+                .json(ErrorMessage("task with id '${taskID.id}' is not found"))
+        } else {
+            LOGGER.info { "Task $taskID removed" }
+            removed.onCanceled()
+            context.status(HttpStatus.NO_CONTENT)
+        }
+    }
+
+    private fun getTaskStatus(context: Context) {
+        val taskID = TaskID.create(context.pathParam(TASK_ID))
+        LOGGER.info { "Checking status for task $taskID" }
+        val taskInfo = tasksLock.read { tasks[taskID] } ?: run {
+            LOGGER.error { "Task $taskID not found" }
+            context.status(HttpStatus.NOT_FOUND)
+                .json(ErrorMessage("task with id '${taskID.id}' is not found"))
+            return
+        }
+        context.status(HttpStatus.OK)
+            .json(taskInfo.toTaskStatusResponse())
+    }
+
+    private fun executeTask(context: Context) {
+        val taskID = TaskID.create(context.pathParam(TASK_ID))
+        LOGGER.info { "Executing task $taskID" }
+        val taskState: TaskState = tasksLock.write {
+            val info = tasks[taskID] ?: run {
+                return@write TaskState.NotFound
+            }
+            val queue = ArrayBlockingQueue<Supplier<SseEvent>>(configuration.responseQueueSize)
+            val handler = HttpMessagesRequestHandler(
+                queue, sseResponseBuilder, convExecutor, dataMeasurement,
+                maxMessagesPerRequest = configuration.bufferPerQuery,
+                responseFormats = info.request.responseFormats
+                    ?: configuration.responseFormats,
+            )
+            if (!info.attachHandler(handler)) {
+                return@write TaskState.AlreadyInProgress
+            }
+            TaskState.Ready(info, handler, queue)
+        }
+        when (taskState) {
+            TaskState.AlreadyInProgress -> {
+                LOGGER.error { "Task $taskID already in progress" }
+                context.status(HttpStatus.CONFLICT)
+                    .json(ErrorMessage("task with id '${taskID.id}' already in progress"))
+            }
+
+            TaskState.NotFound -> {
+                LOGGER.error { "Task $taskID not found" }
+                context.status(HttpStatus.NOT_FOUND)
+                    .json(ErrorMessage("task with id '${taskID.id}' is not found"))
+            }
+
+            is TaskState.Ready -> {
+                val (taskInfo, handler, queue) = taskState
+                keepAliveHandler.addKeepAliveData(handler).use {
+                    searchMessagesHandler.loadMessageGroups(taskInfo.request, handler, dataMeasurement)
+                    writeJsonStream(context, queue, handler, dataMeasurement, LOGGER, taskInfo)
+                    LOGGER.info { "Task $taskID completed with status ${taskInfo.status}" }
+                }
+            }
+        }
+    }
+
+    private sealed class TaskState {
+        object AlreadyInProgress : TaskState()
+        object NotFound : TaskState()
+        data class Ready(
+            val info: TaskInformation,
+            val handler: HttpMessagesRequestHandler,
+            val queue: ArrayBlockingQueue<Supplier<SseEvent>>,
+        ) : TaskState()
+    }
+
+    private fun registerTask(context: Context) {
+        val request = context.bodyValidator<CreateTaskRequest>()
+            .check(
+                CreateTaskRequest::groups.name,
+                { it.groups.isNotEmpty() },
+                "empty value",
+            )
+            .check(
+                CreateTaskRequest::responseFormats.name,
+                { ResponseFormat.isValidCombination(it.responseFormats) },
+                "only one ${ResponseFormat.PROTO_PARSED} or ${ResponseFormat.JSON_PARSED} must be used",
+            )
+            .check(
+                CreateTaskRequest::limit.name,
+                { it.limit == null || it.limit >= 0 },
+                "negative limit",
+            )
+            .get()
+
+        val taskID = TaskID(EventUtils.generateUUID())
+
+        LOGGER.info { "Registering task $taskID" }
+        tasksLock.write { tasks[taskID] = TaskInformation(taskID, request.toGroupRequest()) }
+        LOGGER.info { "Task $taskID registered" }
+
+        context.status(HttpStatus.CREATED)
+            .json(TaskIDResponse(taskID))
+    }
+
+    private data class TaskID(
+        @field:JsonValue
+        val id: String,
+    ) {
+        companion object {
+            @JsonCreator
+            @JvmStatic
+            fun create(id: String): TaskID = TaskID(id)
+        }
+    }
+
+    private class TaskIDResponse(
+        val taskID: TaskID,
+    )
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private class TaskStatusResponse(
+        val taskID: TaskID,
+        val status: TaskStatus,
+        val errors: List<ErrorMessage> = emptyList(),
+    )
+
+    enum class TaskStatus {
+        CREATED,
+        EXECUTING,
+        EXECUTING_WITH_ERRORS,
+        COMPLETED,
+        COMPLETED_WITH_ERRORS,
+        CANCELED,
+    }
+
+    private class TaskInformation(
+        val taskID: TaskID,
+        val request: MessagesGroupRequest,
+    ) : ProgressListener {
+        private var _status: TaskStatus = TaskStatus.CREATED
+        private val _errors: MutableList<ErrorHolder> = ArrayList()
+        private var handler: CancelableResponseHandler? = null
+
+        val status: TaskStatus
+            get() = _status
+        val errors: List<ErrorHolder>
+            get() = _errors
+
+        override fun onStart() {
+            LOGGER.trace { "Task $taskID started" }
+            _status = TaskStatus.EXECUTING
+        }
+
+        override fun onError(ex: Exception) {
+            LOGGER.trace(ex) { "Task $taskID received an error" }
+            _status = TaskStatus.EXECUTING_WITH_ERRORS
+            _errors += ErrorHolder(
+                ExceptionUtils.getMessage(ex),
+                ExceptionUtils.getRootCauseMessage(ex),
+            )
+        }
+
+        override fun onError(errorEvent: SseEvent.ErrorData) {
+            LOGGER.trace { "Task $taskID received error event" }
+            _status = TaskStatus.EXECUTING_WITH_ERRORS
+            _errors += ErrorHolder(
+                errorEvent.data.toString(Charsets.UTF_8)
+            )
+        }
+
+        override fun onCompleted() {
+            LOGGER.trace { "Task $taskID completed" }
+            _status = when (_status) {
+                TaskStatus.CANCELED ->
+                    TaskStatus.CANCELED
+
+                TaskStatus.EXECUTING_WITH_ERRORS ->
+                    TaskStatus.COMPLETED_WITH_ERRORS
+
+                else ->
+                    TaskStatus.COMPLETED
+            }
+        }
+
+        override fun onCanceled() {
+            LOGGER.trace { "Task $taskID canceled" }
+            _status = when (_status) {
+                TaskStatus.EXECUTING_WITH_ERRORS ->
+                    TaskStatus.EXECUTING_WITH_ERRORS
+
+                TaskStatus.COMPLETED_WITH_ERRORS, TaskStatus.COMPLETED ->
+                    _status
+
+                else ->
+                    TaskStatus.CANCELED
+            }
+            handler?.also {
+                if (it.isAlive) {
+                    it.cancel()
+                }
+            }
+        }
+
+        fun attachHandler(handler: CancelableResponseHandler): Boolean {
+            LOGGER.trace { "Attaching handler to task $taskID" }
+            if (this.handler != null) {
+                return false
+            }
+            this.handler = handler
+            return true
+        }
+
+        companion object {
+            private val LOGGER = KotlinLogging.logger(TaskInformation::class.qualifiedName!!)
+        }
+    }
+
+    private class ErrorHolder(
+        val message: String,
+        val cause: String? = null,
+    )
+
+    private fun TaskInformation.toTaskStatusResponse(): TaskStatusResponse =
+        TaskStatusResponse(
+            taskID = taskID,
+            status = status,
+            errors = errors.map { holder ->
+                ErrorMessage(
+                    error = "${holder.message}${holder.cause?.let { " cause $it" } ?: ""}"
+                )
+            }
+        )
+
+    private fun CreateTaskRequest.toGroupRequest(): MessagesGroupRequest {
+        return MessagesGroupRequest(
+            groups = groups,
+            startTimestamp = startTimestamp,
+            endTimestamp = endTimestamp,
+            keepOpen = false,
+            bookId = bookId,
+            responseFormats = responseFormats.ifEmpty { configuration.responseFormats },
+            includeStreams = streams.asSequence().flatMap { it.toProviderMessageStreams() }
+                .toSet(),
+            searchDirection = searchDirection,
+            limit = limit,
+        )
+    }
+
+    private fun MessageStream.toProviderMessageStreams(): Sequence<ProviderMessageStream> {
+        return directions.asSequence().map { ProviderMessageStream(sessionAlias, it) }
+    }
+
+    private class CreateTaskRequest(
+        val resource: Resource,
+        val bookId: BookId,
+        @field:JsonDeserialize(using = CustomMillisOrNanosInstantDeserializer::class)
+        val startTimestamp: Instant,
+        @field:JsonDeserialize(using = CustomMillisOrNanosInstantDeserializer::class)
+        val endTimestamp: Instant,
+        val groups: Set<String>,
+        val responseFormats: Set<ResponseFormat> = emptySet(),
+        val limit: Int? = null,
+        val streams: List<MessageStream> = emptyList(),
+        val searchDirection: SearchDirection = SearchDirection.next,
+    )
+
+    private class MessageStream(
+        val sessionAlias: String,
+        val directions: Set<Direction> = setOf(Direction.SECOND, Direction.FIRST)
+    )
+
+    private enum class Resource {
+        MESSAGES,
+    }
+
+    private class ErrorMessage(
+        val error: String,
+    )
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
+        private const val TASK_ID = "taskID"
+        private const val DOWNLOAD_ROUTE = "/download"
+        private const val TASK_ROUTE = "$DOWNLOAD_ROUTE/{$TASK_ID}"
+        private const val TASK_STATUS_ROUTE = "$DOWNLOAD_ROUTE/{$TASK_ID}/status"
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/TaskDownloadHandler.kt
@@ -47,6 +47,7 @@ import io.javalin.openapi.HttpMethod
 import io.javalin.openapi.Nullability
 import io.javalin.openapi.OpenApi
 import io.javalin.openapi.OpenApiContent
+import io.javalin.openapi.OpenApiDescription
 import io.javalin.openapi.OpenApiExample
 import io.javalin.openapi.OpenApiParam
 import io.javalin.openapi.OpenApiPropertyType
@@ -198,6 +199,7 @@ class TaskDownloadHandler(
                 maxMessagesPerRequest = configuration.bufferPerQuery,
                 responseFormats = info.request.responseFormats
                     ?: configuration.responseFormats,
+                failFast = info.request.failFast,
             )
             if (!info.attachHandler(handler)) {
                 return@write TaskState.AlreadyInProgress
@@ -448,6 +450,7 @@ class TaskDownloadHandler(
                 .toSet(),
             searchDirection = searchDirection,
             limit = limit,
+            failFast = failFast,
         )
     }
 
@@ -475,6 +478,9 @@ class TaskDownloadHandler(
         val streams: List<MessageStream> = emptyList(),
         @get:OpenApiPropertyType(definedBy = SearchDirection::class, nullability = Nullability.NULLABLE)
         val searchDirection: SearchDirection = SearchDirection.next,
+        @get:OpenApiPropertyType(definedBy = Boolean::class, nullability = Nullability.NULLABLE)
+        @get:OpenApiDescription("the request will stop right after the first error reported. Enabled by default")
+        val failFast: Boolean = true,
     )
 
     private class MessageStream(

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/listener/ProgressListener.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/listener/ProgressListener.kt
@@ -23,8 +23,11 @@ interface ProgressListener {
     fun onError(ex: Exception)
     fun onError(errorEvent: SseEvent.ErrorData)
     fun onCompleted()
+
+    fun onCanceled()
 }
 
+@JvmField
 val DEFAULT_PROCESS_LISTENER: ProgressListener = object : ProgressListener {
     override fun onStart() = Unit
 
@@ -33,4 +36,6 @@ val DEFAULT_PROCESS_LISTENER: ProgressListener = object : ProgressListener {
     override fun onError(errorEvent: SseEvent.ErrorData) = Unit
 
     override fun onCompleted() = Unit
+
+    override fun onCanceled() = Unit
 }

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/listener/ProgressListener.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/listener/ProgressListener.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.http.listener
+
+import com.exactpro.th2.lwdataprovider.SseEvent
+
+interface ProgressListener {
+    fun onStart()
+    fun onError(ex: Exception)
+    fun onError(errorEvent: SseEvent.ErrorData)
+    fun onCompleted()
+}
+
+val DEFAULT_PROCESS_LISTENER: ProgressListener = object : ProgressListener {
+    override fun onStart() = Unit
+
+    override fun onError(ex: Exception) = Unit
+
+    override fun onError(errorEvent: SseEvent.ErrorData) = Unit
+
+    override fun onCompleted() = Unit
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/serializers/BookIdDeserializer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/serializers/BookIdDeserializer.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.http.serializers
+
+import com.exactpro.cradle.BookId
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+internal class BookIdDeserializer : StdDeserializer<BookId>(BookId::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): BookId {
+        require(p.currentToken == JsonToken.VALUE_STRING) { "value must be a string" }
+        return BookId(p.valueAsString)
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = -5889633617969813739L
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/serializers/CustomMillisOrNanosInstantDeserializer.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/serializers/CustomMillisOrNanosInstantDeserializer.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.http.serializers
+
+import com.exactpro.th2.lwdataprovider.http.HttpServer
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import java.time.Instant
+
+internal class CustomMillisOrNanosInstantDeserializer : StdDeserializer<Instant>(Instant::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Instant {
+        require(p.currentToken == JsonToken.VALUE_NUMBER_INT) {
+            "cannot deserialize ${Instant::class.simpleName} from ${p.currentToken}"
+        }
+        return HttpServer.convertToInstant(p.longValue)
+    }
+
+    companion object {
+        private const val serialVersionUID: Long = -8423525654021997687L
+    }
+
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.http.util
+
+import com.exactpro.th2.lwdataprovider.EventType
+import com.exactpro.th2.lwdataprovider.SseEvent
+import com.exactpro.th2.lwdataprovider.db.DataMeasurement
+import com.exactpro.th2.lwdataprovider.http.HttpMessagesRequestHandler
+import com.exactpro.th2.lwdataprovider.http.listener.DEFAULT_PROCESS_LISTENER
+import com.exactpro.th2.lwdataprovider.http.listener.ProgressListener
+import com.exactpro.th2.lwdataprovider.metrics.HttpWriteMetrics
+import com.exactpro.th2.lwdataprovider.metrics.ResponseQueue
+import io.javalin.http.Context
+import io.javalin.http.Header
+import io.javalin.http.HttpStatus
+import mu.KLogger
+import org.apache.commons.lang3.StringUtils
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.function.Supplier
+
+const val JSON_STREAM_CONTENT_TYPE = "application/stream+json"
+
+fun writeJsonStream(
+    ctx: Context,
+    queue: ArrayBlockingQueue<Supplier<SseEvent>>,
+    handler: HttpMessagesRequestHandler,
+    dataMeasurement: DataMeasurement,
+    logger: KLogger,
+    progressListener: ProgressListener = DEFAULT_PROCESS_LISTENER,
+) {
+    progressListener.onStart()
+
+    val matchedPath = ctx.matchedPath()
+    var dataSent = 0
+
+    var writeHeader = true
+    var status: HttpStatus = HttpStatus.OK
+
+    fun writeHeader() {
+        if (writeHeader) {
+            ctx.status(status)
+                .contentType(JSON_STREAM_CONTENT_TYPE)
+                .header(Header.TRANSFER_ENCODING, "chunked")
+            writeHeader = false
+        }
+    }
+
+    val output = ctx.res().outputStream.buffered()
+    try {
+        do {
+            dataMeasurement.start("process_sse_event").use {
+                val nextEvent = queue.take()
+                ResponseQueue.currentSize(matchedPath, queue.size)
+                val sseEvent = dataMeasurement.start("await_convert_to_json").use { nextEvent.get() }
+                if (writeHeader && sseEvent is SseEvent.ErrorData.SimpleError) {
+                    // something happened during request
+                    status = HttpStatus.INTERNAL_SERVER_ERROR
+                }
+                writeHeader()
+                if (sseEvent is SseEvent.ErrorData) {
+                    progressListener.onError(sseEvent)
+                }
+                when (sseEvent.event) {
+                    EventType.KEEP_ALIVE -> output.flush()
+                    EventType.CLOSE -> {
+                        logger.info { "Received close event" }
+                        return
+                    }
+
+                    else -> {
+                        logger.debug {
+                            "Write event to output: ${
+                                StringUtils.abbreviate(sseEvent.data.toString(SseEvent.DATA_CHARSET), 100)
+                            }"
+                        }
+                        output.write(sseEvent.data)
+                        output.write('\n'.code)
+                        dataSent++
+                    }
+                }
+            }
+        } while (true)
+    } catch (ex: Exception) {
+        logger.error(ex) { "cannot process next event" }
+        progressListener.onError(ex)
+        handler.cancel()
+        queue.clear()
+    } finally {
+        progressListener.onCompleted()
+        HttpWriteMetrics.messageSent(matchedPath, dataSent)
+        runCatching { output.flush() }
+            .onFailure { logger.error(it) { "cannot flush the remaining data when processing is finished" } }
+    }
+}

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
@@ -100,7 +100,11 @@ fun writeJsonStream(
         handler.cancel()
         queue.clear()
     } finally {
-        progressListener.onCompleted()
+        if (handler.isAlive) {
+            progressListener.onCompleted()
+        } else {
+            progressListener.onCanceled()
+        }
         HttpWriteMetrics.messageSent(matchedPath, dataSent)
         runCatching { output.flush() }
             .onFailure { logger.error(it) { "cannot flush the remaining data when processing is finished" } }

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/http/util/JsonStreamingUtil.kt
@@ -92,6 +92,10 @@ fun writeJsonStream(
                         dataSent++
                     }
                 }
+                if (queue.isEmpty() && !handler.isAlive) {
+                    logger.info { "Request canceled" }
+                    return
+                }
             }
         } while (true)
     } catch (ex: Exception) {

--- a/src/main/kotlin/com/exactpro/th2/lwdataprovider/workers/TaskManager.kt
+++ b/src/main/kotlin/com/exactpro/th2/lwdataprovider/workers/TaskManager.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.workers
+
+import com.exactpro.th2.lwdataprovider.CancelableResponseHandler
+import com.exactpro.th2.lwdataprovider.SseEvent
+import com.exactpro.th2.lwdataprovider.entities.requests.MessagesGroupRequest
+import com.exactpro.th2.lwdataprovider.http.listener.ProgressListener
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import mu.KotlinLogging
+import org.apache.commons.lang3.exception.ExceptionUtils
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import javax.annotation.concurrent.NotThreadSafe
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+import kotlin.math.min
+
+class TaskManager : AutoCloseable, TimeoutChecker {
+    private val tasksLock = ReentrantReadWriteLock()
+    private val tasks: MutableMap<TaskID, TaskInformation> = HashMap()
+
+    operator fun get(taskID: TaskID): TaskInformation? =
+        tasksLock.read { tasks[taskID] }
+
+    operator fun set(taskID: TaskID, information: TaskInformation): Unit =
+        tasksLock.write { tasks[taskID] = information }
+
+    fun remove(taskID: TaskID): TaskInformation? =
+        tasksLock.write { internalRemove(taskID) }
+
+    fun <T> execute(taskID: TaskID, action: (TaskInformation?) -> T): T =
+        tasksLock.write { action(tasks[taskID]) }
+
+    override fun removeOlderThen(timeout: Long): Long {
+        val currentTime = Instant.now()
+        val (tasksToCleanup: Map<TaskID, TaskInformation>, minCreationTime: Instant) = tasksLock.read {
+            val mitTime: Instant = tasks.values.minOfOrNull { info ->
+                info.completionTime?.let { minOf(it, info.creationTime) }
+                    ?: info.creationTime
+            } ?: currentTime
+
+            tasks.filter { (_, info) ->
+                createdButNotStarted(info, currentTime, timeout)
+                        || completed(info, currentTime, timeout)
+            } to mitTime
+        }
+        if (tasksToCleanup.isNotEmpty()) {
+            tasksLock.write {
+                for ((id, info) in tasksToCleanup) {
+                    LOGGER.info { "Canceling task $id in status ${info.status} due to timeout in $timeout mls" }
+                    internalRemove(id)
+                }
+            }
+        }
+        return minCreationTime.toEpochMilli()
+    }
+
+    private fun internalRemove(taskID: TaskID) = tasks.remove(taskID)?.apply(TaskInformation::onCanceled)
+
+    private fun completed(info: TaskInformation, currentTime: Instant, timeout: Long): Boolean {
+        return info.completionTime.let { completedAt ->
+            completedAt != null && checkDiff(currentTime, timeout, completedAt)
+        }
+    }
+
+    private fun createdButNotStarted(info: TaskInformation, currentTime: Instant, timeout: Long) =
+        info.status == TaskStatus.CREATED && checkDiff(currentTime, timeout, info.creationTime)
+
+    private fun checkDiff(currentTime: Instant, timeout: Long, taskTime: Instant) =
+        Duration.between(taskTime, currentTime).abs().toMillis() > timeout
+
+    override fun close() {
+        tasksLock.write {
+            tasks.forEach { (id, taskInfo) ->
+                LOGGER.info { "Closing task $id in status ${taskInfo.status}" }
+                taskInfo.onCanceled()
+            }
+            tasks.clear()
+        }
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger { }
+    }
+}
+
+data class TaskID(
+    @field:JsonValue
+    val id: String,
+) {
+    companion object {
+        @JsonCreator
+        @JvmStatic
+        fun create(id: String): TaskID = TaskID(id)
+    }
+}
+
+enum class TaskStatus {
+    CREATED,
+    EXECUTING,
+    EXECUTING_WITH_ERRORS,
+    COMPLETED,
+    COMPLETED_WITH_ERRORS,
+    CANCELED,
+    CANCELED_WITH_ERRORS,
+}
+
+@NotThreadSafe
+class TaskInformation(
+    val taskID: TaskID,
+    val request: MessagesGroupRequest,
+) : ProgressListener {
+    val creationTime: Instant = Instant.now()
+    @Volatile
+    var completionTime: Instant? = null
+        private set
+    @Volatile
+    private var _status: TaskStatus = TaskStatus.CREATED
+    private val _errors: MutableList<ErrorHolder> = ArrayList()
+    @Volatile
+    private var handler: CancelableResponseHandler? = null
+
+    val status: TaskStatus
+        get() = _status
+    val errors: List<ErrorHolder>
+        get() = _errors.toList()
+
+    override fun onStart() {
+        LOGGER.trace { "Task $taskID started" }
+        _status = TaskStatus.EXECUTING
+    }
+
+    override fun onError(ex: Exception) {
+        LOGGER.trace(ex) { "Task $taskID received an error" }
+        _status = TaskStatus.EXECUTING_WITH_ERRORS
+        _errors += ErrorHolder(
+            ExceptionUtils.getMessage(ex),
+            ExceptionUtils.getRootCauseMessage(ex),
+        )
+    }
+
+    override fun onError(errorEvent: SseEvent.ErrorData) {
+        LOGGER.trace { "Task $taskID received error event" }
+        _status = TaskStatus.EXECUTING_WITH_ERRORS
+        _errors += ErrorHolder(
+            errorEvent.data.toString(Charsets.UTF_8)
+        )
+    }
+
+    override fun onCompleted() {
+        LOGGER.trace { "Task $taskID completed" }
+        _status = when (_status) {
+            TaskStatus.CANCELED ->
+                TaskStatus.CANCELED
+
+            TaskStatus.EXECUTING_WITH_ERRORS ->
+                TaskStatus.COMPLETED_WITH_ERRORS
+
+            TaskStatus.CREATED,
+            TaskStatus.EXECUTING,
+            TaskStatus.COMPLETED,
+            TaskStatus.COMPLETED_WITH_ERRORS,
+            TaskStatus.CANCELED_WITH_ERRORS ->
+                TaskStatus.COMPLETED
+        }
+        completionTime = Instant.now()
+    }
+
+    override fun onCanceled() {
+        LOGGER.trace { "Task $taskID canceled" }
+        _status = when (_status) {
+            TaskStatus.EXECUTING_WITH_ERRORS ->
+                TaskStatus.CANCELED_WITH_ERRORS
+
+            TaskStatus.COMPLETED_WITH_ERRORS,
+            TaskStatus.COMPLETED ->
+                _status
+
+            TaskStatus.CREATED,
+            TaskStatus.EXECUTING,
+            TaskStatus.CANCELED,
+            TaskStatus.CANCELED_WITH_ERRORS ->
+                TaskStatus.CANCELED
+        }
+        handler?.also {
+            if (it.isAlive) {
+                it.cancel()
+            }
+        }
+        completionTime = Instant.now()
+    }
+
+    fun attachHandler(handler: CancelableResponseHandler): Boolean {
+        LOGGER.trace { "Attaching handler to task $taskID" }
+        if (this.handler != null) {
+            return false
+        }
+        this.handler = handler
+        return true
+    }
+
+    companion object {
+        private val LOGGER = KotlinLogging.logger(TaskInformation::class.qualifiedName!!)
+    }
+}
+
+class ErrorHolder(
+    val message: String,
+    val cause: String? = null,
+)

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
@@ -70,7 +70,7 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
     )
     protected open val configuration = Configuration(
         CustomConfigurationClass(
-            decodingTimeout = 200,
+            decodingTimeout = 400,
         )
     )
 
@@ -250,6 +250,9 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
 
     protected fun Assertion.Builder<Response>.jsonBody(): Assertion.Builder<JsonNode> =
         get { body }.isNotNull().get { MAPPER.readTree(bytes()) }
+
+    protected fun Response.bodyAsJson(): JsonNode =
+        MAPPER.readTree(requireNotNull(body) { "empty body" }.bytes())
 
     protected fun HttpClient.sse(path: String, requestCfg: Request.Builder.() -> Unit = {}): Response = get(path) {
         requestCfg(it)

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
@@ -281,7 +281,7 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
         fun expectEventually(
             timeout: Long,
             delay: Long = 100,
-            description: String = "expected condition was not mat withing $timeout mls",
+            description: String = "expected condition was not met withing $timeout mls",
             action: suspend () -> Boolean,
         ): Assertion.Builder<Result<Unit>> {
             require(timeout > 0) { "invalid timeout value $timeout" }
@@ -294,7 +294,7 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
                     }
                     Thread.sleep(delay)
                 }
-                throw IllegalStateException("condition was not mat")
+                throw IllegalStateException("condition was not met")
             }.describedAs(description)
         }
 
@@ -311,7 +311,7 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
                 val deadline = System.currentTimeMillis() + timeout
                 while (System.currentTimeMillis() < deadline) {
                     if (action()) {
-                        throw IllegalStateException("condition is mat")
+                        throw IllegalStateException("condition is met")
                     }
                     Thread.sleep(delay)
                 }

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/AbstractHttpHandlerTest.kt
@@ -68,6 +68,11 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
             .setNameFormat("test-executor-%d")
             .build()
     )
+    private val converterExecutor = Executors.newSingleThreadExecutor(
+        ThreadFactoryBuilder()
+            .setNameFormat("test-conv-executor-%d")
+            .build()
+    )
     protected open val configuration = Configuration(
         CustomConfigurationClass(
             decodingTimeout = 400,
@@ -120,7 +125,7 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
             transportMessageRouter = transportMessageRouter,
             eventRouter = eventRouter,
             execExecutor = executor,
-            convExecutor = executor,
+            convExecutor = converterExecutor,
             applicationName = "test-lw-data-provider",
         )
     }
@@ -137,6 +142,8 @@ abstract class AbstractHttpHandlerTest<T : JavalinHandler> {
     fun shutdown() {
         context.keepAliveHandler.stop()
         context.timeoutHandler.stop()
+        executor.shutdown()
+        converterExecutor.shutdown()
     }
 
     @BeforeEach

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
@@ -1,0 +1,302 @@
+package com.exactpro.th2.lwdataprovider.http
+
+import com.exactpro.cradle.Direction
+import com.exactpro.cradle.messages.StoredGroupedMessageBatch
+import com.exactpro.cradle.messages.StoredMessageIdUtils
+import com.exactpro.th2.lwdataprovider.util.CradleResult
+import com.exactpro.th2.lwdataprovider.util.GroupBatch
+import com.exactpro.th2.lwdataprovider.util.createCradleStoredMessage
+import io.javalin.http.HttpStatus
+import io.javalin.testtools.TestConfig
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.allIndexed
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.jackson.has
+import strikt.jackson.hasSize
+import strikt.jackson.isArray
+import strikt.jackson.isObject
+import strikt.jackson.isTextual
+import strikt.jackson.path
+import strikt.jackson.textValue
+import java.time.Duration
+import java.time.Instant
+
+class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
+    override fun createHandler(): TaskDownloadHandler {
+        return TaskDownloadHandler(
+            configuration,
+            convExecutor = context.convExecutor,
+            sseResponseBuilder,
+            keepAliveHandler = context.keepAliveHandler,
+            searchMessagesHandler = context.searchMessagesHandler,
+            context.requestsDataMeasurement,
+        )
+    }
+
+    @Test
+    fun `creates task`() {
+        startTest { _, client ->
+            val response = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to Instant.now().toEpochMilli(),
+                    "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
+                    "groups" to setOf("group1", "group2"),
+                    "limit" to 42,
+                    "streams" to listOf(
+                        mapOf(
+                            "sessionAlias" to "test",
+                            "directions" to setOf("FIRST"),
+                        ),
+                    ),
+                    "searchDirection" to "previous",
+                    "responseFormats" to setOf("BASE_64", "JSON_PARSED"),
+                )
+            )
+
+            expectThat(response) {
+                get { code } isEqualTo HttpStatus.CREATED.code
+                jsonBody()
+                    .isObject()
+                    .has("taskID")
+                    .path("taskID")
+                    .isTextual()
+            }
+        }
+    }
+
+    @Test
+    fun `removes existing task`() {
+        startTest { _, client ->
+            val response = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to Instant.now().toEpochMilli(),
+                    "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
+                    "groups" to setOf("group1", "group2"),
+                )
+            )
+            val taskID = response.bodyAsJson()["taskID"].asText()
+            val deleteResp = client.delete(
+                path = "/download/$taskID"
+            )
+
+            expectThat(deleteResp) {
+                get { code } isEqualTo HttpStatus.NO_CONTENT.code
+            }
+        }
+    }
+
+    @Test
+    fun `checks status for existing task`() {
+        startTest { _, client ->
+            val createResp = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to Instant.now().toEpochMilli(),
+                    "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
+                    "groups" to setOf("group1", "group2"),
+                )
+            )
+            val taskID = createResp.bodyAsJson()["taskID"].asText()
+            val deleteResp = client.get(
+                path = "/download/$taskID/status"
+            )
+
+            expectThat(deleteResp) {
+                get { code } isEqualTo HttpStatus.OK.code
+                jsonBody()
+                    .isObject()
+                    .apply {
+                        path("taskID").textValue() isEqualTo taskID
+                        path("status").textValue() isEqualTo "CREATED"
+                        not().has("errors")
+                    }
+            }
+        }
+    }
+
+    @Test
+    fun `launches the existing task`() {
+        val start = Instant.now()
+        doReturn(
+            CradleResult(
+                generateBatch(start, 6)
+            )
+        ).whenever(storage).getGroupedMessageBatches(argThat {
+            groupName == "test-group" && bookId.name == "test-book"
+        })
+
+        startTest { _, client ->
+            val createResp = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to start.toEpochMilli(),
+                    "endTimestamp" to Instant.now().toEpochMilli(),
+                    "groups" to setOf("test-group"),
+                    "responseFormats" to setOf("BASE_64"),
+                )
+            )
+            val taskID = createResp.bodyAsJson()["taskID"].asText()
+            val response = client.get("/download/$taskID")
+
+            val expectedTimestamp = StoredMessageIdUtils.timestampToString(start)
+            val seconds = start.epochSecond
+            val nanos = start.nano
+            expectThat(response) {
+                get { code } isEqualTo HttpStatus.OK.code
+                get { body?.bytes()?.toString(Charsets.UTF_8) }
+                    .isNotNull()
+                    .isEqualTo(
+                        """{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-0","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-0:1:${expectedTimestamp}:1"}
+                          |{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-1","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-1:1:${expectedTimestamp}:2"}
+                          |{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-2","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-2:1:${expectedTimestamp}:3"}
+                          |{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-0","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-0:1:${expectedTimestamp}:4"}
+                          |{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-1","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-1:1:${expectedTimestamp}:5"}
+                          |{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-2","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-2:1:${expectedTimestamp}:6"}
+                          |""".trimMargin(marginPrefix = "|")
+                    )
+            }
+        }
+    }
+
+    @Test
+    fun `report decoding timeout during task execution`() {
+        val start = Instant.now()
+        doReturn(
+            CradleResult(
+                generateBatch(start, 3)
+            )
+        ).whenever(storage).getGroupedMessageBatches(argThat {
+            groupName == "test-group" && bookId.name == "test-book"
+        })
+
+        startTest { _, client ->
+            val createResp = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to start.toEpochMilli(),
+                    "endTimestamp" to Instant.now().toEpochMilli(),
+                    "groups" to setOf("test-group"),
+                    "responseFormats" to setOf("JSON_PARSED"),
+                )
+            )
+            val taskID = createResp.bodyAsJson()["taskID"].asText()
+
+            val expectedTimestamp = StoredMessageIdUtils.timestampToString(start)
+            expect {
+                that(client.get("/download/$taskID")) {
+                    get { code } isEqualTo HttpStatus.OK.code
+                    get { body?.bytes()?.toString(Charsets.UTF_8) }
+                        .isNotNull()
+                        .isEqualTo(
+                            """{"id":"test-book:test-0:1:$expectedTimestamp:1","error":"Codec response wasn\u0027t received during timeout"}
+                              |{"id":"test-book:test-1:1:$expectedTimestamp:2","error":"Codec response wasn\u0027t received during timeout"}
+                              |{"id":"test-book:test-2:1:$expectedTimestamp:3","error":"Codec response wasn\u0027t received during timeout"}
+                              |""".trimMargin(marginPrefix = "|")
+                        )
+                }
+                that(client.get("/download/$taskID/status")) {
+                    get { code } isEqualTo HttpStatus.OK.code
+                    jsonBody()
+                        .isObject() and {
+                            path("status").textValue() isEqualTo "COMPLETED_WITH_ERRORS"
+                            path("errors").isArray()
+                                .hasSize(3)
+                                .allIndexed {
+                                    path("error").textValue() isEqualTo
+                                            "{\"id\":\"test-book:test-$it:1:$expectedTimestamp:${it + 1}\",\"error\":\"Codec response wasn\\u0027t received during timeout\"}"
+                                }
+                        }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `task cannot be started twice`() {
+        val start = Instant.now()
+        doReturn(
+            CradleResult(
+                generateBatch(start, 1)
+            )
+        ).whenever(storage).getGroupedMessageBatches(argThat {
+            groupName == "test-group" && bookId.name == "test-book"
+        })
+
+        startTest { _, client ->
+            val createResp = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookId" to "test-book",
+                    "startTimestamp" to start.toEpochMilli(),
+                    "endTimestamp" to Instant.now().toEpochMilli(),
+                    "groups" to setOf("test-group"),
+                    "responseFormats" to setOf("BASE_64"),
+                )
+            )
+            val taskID = createResp.bodyAsJson()["taskID"].asText()
+
+            val expectedTimestamp = StoredMessageIdUtils.timestampToString(start)
+            val seconds = start.epochSecond
+            val nanos = start.nano
+            expect {
+                that(client.get("/download/$taskID")) {
+                    get { code } isEqualTo HttpStatus.OK.code
+                    get { body?.bytes()?.toString(Charsets.UTF_8) }
+                        .isNotNull()
+                        .isEqualTo(
+                            """{"timestamp":{"epochSecond":${seconds},"nano":${nanos}},"direction":"IN","sessionId":"test-0","messageType":"","attachedEventIds":[],"body":{},"bodyBase64":"aGVsbG8=","messageId":"test-book:test-0:1:${expectedTimestamp}:1"}
+                              |""".trimMargin(marginPrefix = "|")
+                        )
+                }
+                that(client.get("/download/$taskID")) {
+                    get { code } isEqualTo HttpStatus.CONFLICT.code
+                    jsonBody()
+                        .isObject()
+                        .path("error")
+                        .textValue() isEqualTo "task with id '$taskID' already in progress"
+                }
+            }
+        }
+    }
+
+    private fun generateBatch(start: Instant, count: Int, index: Long = 1L): StoredGroupedMessageBatch {
+        var startIndex = index
+        return GroupBatch(
+            "test-group",
+            book = "test-book",
+            messages = buildList {
+                repeat(count) {
+                    add(
+                        createCradleStoredMessage(
+                            "test-${it % 3}",
+                            Direction.FIRST,
+                            startIndex++,
+                            timestamp = start,
+                            book = "test-book",
+                        )
+                    )
+                }
+            },
+        )
+    }
+}

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
@@ -277,7 +277,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
             expectEventually(
                 timeout = downloadTaskTTL + 500L,
                 delay = 300L,
-                description = "executing task with id $taskID was removed due cleanup timeout",
+                description = "completed task with id $taskID was not removed due cleanup timeout",
             ) {
                 client.get("/download/$taskID/status").use {
                     it.code == HttpStatus.NOT_FOUND.code

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.exactpro.th2.lwdataprovider.http
 
 import com.exactpro.cradle.Direction

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/http/TestTaskDownloadHandler.kt
@@ -47,7 +47,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to Instant.now().toEpochMilli(),
                     "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
                     "groups" to setOf("group1", "group2"),
@@ -75,13 +75,42 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
     }
 
     @Test
+    fun `reports incorrect params`() {
+        startTest { _, client ->
+            val response = client.post(
+                path = "/download",
+                json = mapOf(
+                    "resource" to "MESSAGES",
+                    "bookID" to "",
+                    "startTimestamp" to Instant.now().toEpochMilli(),
+                    "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
+                    "groups" to emptySet<String>(),
+                    "limit" to -5,
+                    "searchDirection" to "previous",
+                    "responseFormats" to setOf("PROTO_PARSED", "JSON_PARSED"),
+                )
+            )
+
+            expectThat(response) {
+                get { code } isEqualTo HttpStatus.BAD_REQUEST.code
+                jsonBody()
+                    .isObject()
+                    .has("bookID")
+                    .has("groups")
+                    .has("limit")
+                    .has("responseFormats")
+            }
+        }
+    }
+
+    @Test
     fun `removes existing task`() {
         startTest { _, client ->
             val response = client.post(
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to Instant.now().toEpochMilli(),
                     "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
                     "groups" to setOf("group1", "group2"),
@@ -105,7 +134,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to Instant.now().toEpochMilli(),
                     "endTimestamp" to Instant.now().plusSeconds(10).toEpochMilli(),
                     "groups" to setOf("group1", "group2"),
@@ -145,7 +174,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to start.toEpochMilli(),
                     "endTimestamp" to Instant.now().toEpochMilli(),
                     "groups" to setOf("test-group"),
@@ -191,7 +220,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to start.toEpochMilli(),
                     "endTimestamp" to Instant.now().toEpochMilli(),
                     "groups" to setOf("test-group"),
@@ -246,7 +275,7 @@ class TestTaskDownloadHandler : AbstractHttpHandlerTest<TaskDownloadHandler>() {
                 path = "/download",
                 json = mapOf(
                     "resource" to "MESSAGES",
-                    "bookId" to "test-book",
+                    "bookID" to "test-book",
                     "startTimestamp" to start.toEpochMilli(),
                     "endTimestamp" to Instant.now().toEpochMilli(),
                     "groups" to setOf("test-group"),

--- a/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
+++ b/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
@@ -27,6 +27,7 @@ import com.exactpro.cradle.resultset.CradleResultSet
 import com.exactpro.cradle.testevents.StoredTestEventId
 import com.exactpro.cradle.testevents.StoredTestEventSingle
 import com.exactpro.cradle.testevents.TestEventSingleToStore
+import org.apache.logging.log4j.util.Supplier
 import java.time.Instant
 
 fun createCradleStoredMessage(
@@ -109,8 +110,23 @@ class ImmutableListCradleResult<T>(collection: Collection<T>) : CradleResultSet<
     override fun next(): T = iterator.next()
 }
 
+class SupplierCradleResult<T>(
+    suppliers: Collection<Supplier<T>>,
+) : CradleResultSet<T> {
+    private val iterator: Iterator<Supplier<T>> = suppliers.iterator()
+    override fun remove() = throw UnsupportedOperationException()
+
+    override fun hasNext(): Boolean = iterator.hasNext()
+
+    override fun next(): T = iterator.next().get()
+
+}
+
 @Suppress("TestFunctionName")
 fun <T> CradleResult(vararg data: T): CradleResultSet<T> = ImmutableListCradleResult(data.toList())
+
+@Suppress("TestFunctionName")
+fun <T> SupplierResult(vararg suppliers: Supplier<T>): CradleResultSet<T> = SupplierCradleResult(suppliers.toList())
 
 const val TEST_SESSION_GROUP = "test-group"
 const val TEST_SESSION_ALIAS = "test-alias"


### PR DESCRIPTION
The API to manage download as task is required to get the task's status and see if any errors happened during task execution.
Also parameter for fail-fast strategy was added to provide an ability to stop download once the first error happened.