### PR TITLE
Avoid deadlock with fail-fast strategy in task API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lightweight data provider (2.13.0)
+# Lightweight data provider (2.13.1)
 
 # Overview
 This component serves as a data provider for [th2-data-services](https://github.com/th2-net/th2-data-services). It will connect to the cassandra database via [cradle api](https://github.com/th2-net/cradleapi) and expose the data stored in there as REST resources.
@@ -223,6 +223,12 @@ spec:
 ```
 
 # Release notes:
+
+## 2.13.1
+
+### Fix:
+
++ Possible deadlock when `task` API is used with `fail-fast` strategy and a codec error happens when the response buffer is full
 
 ## 2.13.0
 

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
-release_version=2.13.0
+release_version=2.13.1
 description='th2 Lightweight data provider component'
 kapt.include.compile.classpath=false

--- a/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
+++ b/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/util/CradleTestUtil.kt
@@ -131,6 +131,9 @@ fun <T> CradleResult(vararg data: T): CradleResultSet<T> = ImmutableListCradleRe
 @Suppress("TestFunctionName")
 fun <T> SupplierResult(vararg suppliers: Supplier<T>): CradleResultSet<T> = SupplierCradleResult(suppliers.toList())
 
+@Suppress("TestFunctionName")
+fun <T> SupplierResult(suppliers: List<Supplier<T>>): CradleResultSet<T> = SupplierCradleResult(suppliers)
+
 const val TEST_SESSION_GROUP = "test-group"
 const val TEST_SESSION_ALIAS = "test-alias"
 


### PR DESCRIPTION
When `task` API is used with a fail-fast strategy there is a case when it can cause a deadlock:

- fail-fast is enabled;
- HTTP thread is waiting on a future that waits for codec response;
- internal response queue is full;
- codec request is canceled due to timeout.

In this case, because of the fail-fast strategy, we try to put a close event to the buffer and cannot do that because it is full. And because of that, the future that the HTTP thread waits for cannot be completed.