### PR TITLE
Remove only outdated codec requests from waiting queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lightweight data provider (2.13.2)
+# Lightweight data provider (2.13.3)
 
 # Overview
 This component serves as a data provider for [th2-data-services](https://github.com/th2-net/th2-data-services). It will connect to the cassandra database via [cradle api](https://github.com/th2-net/cradleapi) and expose the data stored in there as REST resources.
@@ -223,6 +223,13 @@ spec:
 ```
 
 # Release notes:
+
+## 2.13.3
+
+### Fix:
+
++ If two requests have been made using same parameters but one is after another the later one can get a codec timeout
+  when the first request gets codec timeout, but it should not because it was made later.
 
 ## 2.13.2
 

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
-release_version=2.13.2
+release_version=2.13.3
 description='th2 Lightweight data provider component'
 kapt.include.compile.classpath=false

--- a/app/src/main/kotlin/com/exactpro/th2/lwdataprovider/workers/DecodeQueueBuffer.kt
+++ b/app/src/main/kotlin/com/exactpro/th2/lwdataprovider/workers/DecodeQueueBuffer.kt
@@ -119,7 +119,7 @@ class DecodeQueueBuffer(
                 val expired = details.count(isExpired)
                 // we are under lock so details won't change during execution
                 when {
-                    expired == details.size -> {
+                    expired == initialSize -> {
                         entries.remove()
                         decodeTimers.remove(id)?.close()
                         LOGGER.trace { "Requests for message $id were cancelled due to timeout" }

--- a/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/workers/TestDecodeQueueBuffer.kt
+++ b/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/workers/TestDecodeQueueBuffer.kt
@@ -30,9 +30,7 @@ import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import strikt.api.expect
-import strikt.api.expectThat
 import strikt.assertions.containsExactly
-import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNotNull

--- a/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/workers/TestDecodeQueueBuffer.kt
+++ b/app/src/test/kotlin/com/exactpro/th2/lwdataprovider/workers/TestDecodeQueueBuffer.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2025 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.lwdataprovider.workers
+
+import com.exactpro.cradle.messages.StoredMessage
+import com.exactpro.cradle.messages.StoredMessageId
+import com.exactpro.cradle.utils.TimeUtils
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.transport.Direction
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.transport.MessageId
+import com.exactpro.th2.common.schema.message.impl.rabbitmq.transport.ParsedMessage
+import com.exactpro.th2.lwdataprovider.RequestedMessageDetails
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+import strikt.assertions.isSuccess
+import strikt.assertions.isTrue
+
+class TestDecodeQueueBuffer {
+    private val buffer = DecodeQueueBuffer()
+
+    @Test
+    fun `only expired requests are removed on timeout`() {
+        val storedMessage = mock<StoredMessage> {
+            on { id } doReturn StoredMessageId.fromString("test:sessionAlias:2:20201031010203123456789:1")
+        }
+        val onResponseExpired = mock<(RequestedMessageDetails) -> Unit>()
+        val onResponseNotExpired = mock<(RequestedMessageDetails) -> Unit>()
+
+        val currentTime = System.currentTimeMillis()
+        val expired = RequestedMessageDetails(
+            storedMessage = storedMessage,
+            onResponse = onResponseExpired,
+        ).apply {
+            time = currentTime - 1000
+        }
+        val notExpired = RequestedMessageDetails(
+            storedMessage = storedMessage,
+            onResponse = onResponseNotExpired,
+        ).apply {
+            time = currentTime
+        }
+        buffer.add(expired, "test")
+        buffer.add(notExpired, "test")
+
+        val minTime = buffer.removeOlderThan(999)
+
+        expect {
+            that(expired) {
+                get { completed }
+                    .get { isDone }
+                    .isTrue()
+
+                get { transportParsedMessages }.isNull()
+                get { protoParsedMessages }.isNull()
+            }
+            that(notExpired) {
+                get { completed }
+                    .get { isDone }
+                    .isFalse()
+            }
+
+            that(minTime).isEqualTo(currentTime)
+
+            catching {
+                verify(onResponseExpired).invoke(same(expired))
+            }.isSuccess()
+
+            catching {
+                verifyNoInteractions(onResponseNotExpired)
+            }.isSuccess()
+        }
+    }
+
+    @Test
+    fun `remaining requests can be marked as done`() {
+        val storedMessage = mock<StoredMessage> {
+            on { id } doReturn StoredMessageId.fromString("test:sessionAlias:2:20201031010203123456789:1")
+        }
+        val onResponseExpired = mock<(RequestedMessageDetails) -> Unit>()
+        val onResponseNotExpired = mock<(RequestedMessageDetails) -> Unit>()
+
+        val currentTime = System.currentTimeMillis()
+        val expired = RequestedMessageDetails(
+            storedMessage = storedMessage,
+            onResponse = onResponseExpired,
+        ).apply {
+            time = currentTime - 1000
+        }
+        val notExpired = RequestedMessageDetails(
+            storedMessage = storedMessage,
+            onResponse = onResponseNotExpired,
+        ).apply {
+            time = currentTime
+        }
+        buffer.add(expired, "test")
+        buffer.add(notExpired, "test")
+
+        buffer.removeOlderThan(999)
+
+        expect {
+            that(expired) {
+                get { completed }
+                    .get { isDone }
+                    .isTrue()
+
+                get { transportParsedMessages }.isNull()
+                get { protoParsedMessages }.isNull()
+            }
+            that(notExpired) {
+                get { completed }
+                    .get { isDone }
+                    .isFalse()
+            }
+        }
+
+
+        buffer.responseTransportReceived(TransportRequestId(
+            bookName = "test",
+            messageID = MessageId.builder()
+                .setDirection(Direction.OUTGOING)
+                .setSessionAlias("sessionAlias")
+                .setTimestamp(TimeUtils.fromIdTimestamp("20201031010203123456789"))
+                .setSequence(1)
+                .build()
+        )) { listOf(ParsedMessage.EMPTY) }
+
+        expect {
+            that(notExpired) {
+                get { completed }
+                    .get { isDone }
+                    .isTrue()
+                get { transportParsedMessages }.isNotNull().containsExactly(ParsedMessage.EMPTY)
+            }
+            catching {
+                verify(onResponseNotExpired).invoke(same(notExpired))
+            }.isSuccess()
+        }
+    }
+}


### PR DESCRIPTION
There was a chance to get a codec timeout when it should not happen:

1. The first HTTP request is made. The request gets canceled by the caller (codec queue still contains sent requests)
2. Immediately after, the second HTTP request is made using the same parameters
3. The codec does not respond fast enough (it can be restarted or something else) and one of the old requests gets timed out
4. The second request gets a codec timeout because it requested the same data (but it should not - only the codec request from the first HTTP request should be timed out)