### PR TITLE
Update javalin and dependent components versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ spec:
 
 # Release notes:
 
+## Unreleased
+
+### Update:
+
++ Update Javalin to `6.4.0`
++ Use Java 21 as build-time and runtime JVM
+
 ## 2.13.3
 
 ### Fix:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 kotlin = "1.9.23"
 th2-plugin = "0.2.3"
 strikt = "0.34.1"
-javalin = "6.3.0"
-openapi = "6.3.0"
+javalin = "6.4.0"
+openapi = "6.4.0"
 
 [libraries]
 th2-common = { group = "com.exactpro.th2", name = "common", version = "5.14.0-dev" }


### PR DESCRIPTION
Does not look like any behavior has changed. Only dependencies were updated.

Release notes:

https://github.com/javalin/javalin/releases/tag/javalin-parent-6.4.0